### PR TITLE
feat: onboarding context to replace route

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { StatusBar } from 'react-native';
 
 import { I18nextProvider } from 'react-i18next';
@@ -6,11 +6,14 @@ import RNBootSplash from 'react-native-bootsplash';
 
 import i18next from '@config/i18n';
 import { storage } from '@config/storage';
+import { OnboardingContext } from '@config/contexts';
 import Routes from '@routes/Routes';
 import { OnboardingScreen } from '@screens';
 
 const App = () => {
-  const isOnboardingComplete = storage.getBoolean('isOnboardingComplete');
+  const [isOnboardingComplete, setIsOnboardingComplete] = useState(
+    storage.getBoolean('isOnboardingComplete') || false,
+  );
 
   useEffect(() => {
     setTimeout(() => {
@@ -19,10 +22,13 @@ const App = () => {
   }, []);
 
   return (
-    <I18nextProvider i18n={i18next}>
-      <StatusBar barStyle="default" />
-      {isOnboardingComplete ? <Routes /> : <OnboardingScreen />}
-    </I18nextProvider>
+    <OnboardingContext.Provider
+      value={{ isOnboardingComplete, setIsOnboardingComplete }}>
+      <I18nextProvider i18n={i18next}>
+        <StatusBar barStyle="default" />
+        {isOnboardingComplete ? <Routes /> : <OnboardingScreen />}
+      </I18nextProvider>
+    </OnboardingContext.Provider>
   );
 };
 

--- a/app/components/OnboardingButton/OnboardingButton.tsx
+++ b/app/components/OnboardingButton/OnboardingButton.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useState, useContext } from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 
 import { useTranslation } from 'react-i18next';
@@ -17,6 +17,7 @@ import { HAPTIC_FEEDBACK_OPTIONS, SCREEN_DIMENSIONS } from '@config/constants';
 
 import { ONBOARDING_TOTAL_STEPS } from '@screens';
 import { storage } from '@config/storage';
+import { OnboardingContext } from '@config/contexts';
 import { stylesheet } from './styles';
 
 type OnboardingButtonProps = {
@@ -31,6 +32,7 @@ export const OnboardingButton = ({
   mask,
 }: OnboardingButtonProps) => {
   const [loading, setLoading] = useState<boolean>(false);
+  const { setIsOnboardingComplete } = useContext(OnboardingContext);
   const { styles } = useStyles(stylesheet);
   const { t } = useTranslation();
 
@@ -46,6 +48,7 @@ export const OnboardingButton = ({
       setTimeout(() => setLoading(false), 1000);
     } else {
       storage.set('isOnboardingComplete', true);
+      setIsOnboardingComplete(true);
       trigger('impactLight', HAPTIC_FEEDBACK_OPTIONS);
     }
   };

--- a/app/config/contexts.ts
+++ b/app/config/contexts.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+type OnboardingContextType = {
+  isOnboardingComplete: boolean;
+  setIsOnboardingComplete: (value: boolean) => void;
+};
+
+export const OnboardingContext = createContext<OnboardingContextType>({
+  isOnboardingComplete: false,
+  setIsOnboardingComplete: () => {},
+});


### PR DESCRIPTION
### ✨ Description:
add a context to the onboarding screen so it can trigger the render to replace the routes

### 🛠 Changes

- [X] : add a context to manage the app route state

### 🧪 How Has This Been Tested?

- [X] Tested on iOS
