### PR TITLE
fix: use react useTranslation hook instead direct usage i18next.t on bottom-tabs

### DIFF
--- a/app/routes/Routes.tsx
+++ b/app/routes/Routes.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unstable-nested-components */
 import { NavigationContainer } from '@react-navigation/native';
 import { createMotionTabs } from 'react-native-motion-tabs';
-import i18next from '@config/i18n';
+import { useTranslation } from 'react-i18next';
 
 import {
   HomeScreen,
@@ -10,28 +10,30 @@ import {
   ThemeScreen,
 } from '@screens';
 
+const { t } = useTranslation();
+
 const Tabs = createMotionTabs({
   tabs: [
     {
-      name: i18next.t('homeBottomTab'),
+      name: t('homeBottomTab'),
       component: HomeScreen,
       icon: 'quote',
       iconType: 'Entypo',
     },
     {
-      name: i18next.t('favoritesBottomTab'),
+      name: t('favoritesBottomTab'),
       component: FavoritesScreen,
       icon: 'heart-outline',
       iconType: 'Ionicons',
     },
     {
-      name: i18next.t('themeBottomTab'),
+      name: t('themeBottomTab'),
       component: ThemeScreen,
       icon: 'color-palette-outline',
       iconType: 'Ionicons',
     },
     {
-      name: i18next.t('profileBottomTab'),
+      name: t('profileBottomTab'),
       component: ProfileScreen,
       icon: 'paw',
       iconType: 'Ionicons',


### PR DESCRIPTION
### ✨ Description:
Replaced direct usage of methods like i18next.t or i18next.changeLanguage with the useTranslation hook in bottom-tabs.

### 🛠 Changes

- [X] : use React useTranslation hook on bottom-tabs

### 🧪 How Has This Been Tested?

- [x] Tested on iOS
- [x] Tested on Android