### PR TITLE
fix(android): replace deprecated showPopupMenu

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,7 @@ import { OnboardingContext } from '@config/contexts';
 import Routes from '@routes/Routes';
 import { OnboardingScreen } from '@screens';
 import { configurePurchases } from '@services';
+import { PaperProvider } from 'react-native-paper';
 
 const App = () => {
   const [isOnboardingComplete, setIsOnboardingComplete] = useState(() => {
@@ -25,13 +26,15 @@ const App = () => {
   }, []);
 
   return (
-    <OnboardingContext.Provider
-      value={{ isOnboardingComplete, setIsOnboardingComplete }}>
-      <I18nextProvider i18n={i18next}>
-        <StatusBar barStyle="default" />
-        {isOnboardingComplete ? <Routes /> : <OnboardingScreen />}
-      </I18nextProvider>
-    </OnboardingContext.Provider>
+    <PaperProvider>
+      <OnboardingContext.Provider
+        value={{ isOnboardingComplete, setIsOnboardingComplete }}>
+        <I18nextProvider i18n={i18next}>
+          <StatusBar barStyle="default" />
+          {isOnboardingComplete ? <Routes /> : <OnboardingScreen />}
+        </I18nextProvider>
+      </OnboardingContext.Provider>
+    </PaperProvider>
   );
 };
 

--- a/app/components/FavoritesOptionsMenu/FavoritesOptionsMenu.tsx
+++ b/app/components/FavoritesOptionsMenu/FavoritesOptionsMenu.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { TouchableOpacity } from 'react-native';
+import { Menu, Divider } from 'react-native-paper';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+import { useTranslation } from 'react-i18next';
+
+type FavoritesOptionsMenuProps = {
+  onDelete: () => void;
+};
+
+export const FavoritesOptionsMenu = ({
+  onDelete,
+}: FavoritesOptionsMenuProps) => {
+  const [visible, setVisible] = useState(false);
+  const { t } = useTranslation();
+
+  const openMenu = () => setVisible(true);
+  const closeMenu = () => setVisible(false);
+
+  return (
+    <Menu
+      visible={visible}
+      onDismiss={closeMenu}
+      anchor={
+        <TouchableOpacity onPress={openMenu}>
+          <MaterialCommunityIcons
+            name="dots-vertical"
+            color="#000000"
+            size={22}
+          />
+        </TouchableOpacity>
+      }>
+      <Menu.Item
+        onPress={() => {
+          closeMenu();
+          onDelete();
+        }}
+        title={t('delete')}
+      />
+      <Divider />
+      <Menu.Item onPress={closeMenu} title={t('cancel')} />
+    </Menu>
+  );
+};

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -6,3 +6,4 @@ export * from './OnboardingImages/OnboardingImages';
 export * from './QuoteShareImage/QuoteShareImage';
 export * from './ThemeImage/ThemeImage';
 export * from './ThemeBackdrop/ThemeBackdrop';
+export * from './FavoritesOptionsMenu/FavoritesOptionsMenu';

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,7 @@ module.exports = {
   presets: ['module:@react-native/babel-preset'],
   plugins: [
     'react-native-reanimated/plugin',
+    ['react-native-paper/babel'],
     [
       'module-resolver',
       {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-native-localize": "^3.2.1",
     "react-native-mmkv": "3.0.2",
     "react-native-motion-tabs": "^1.0.6",
+    "react-native-paper": "^5.13.1",
     "react-native-purchases": "^8.5.0",
     "react-native-reanimated": "^3.15.0",
     "react-native-safe-area-context": "^4.10.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1073,6 +1073,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@callstack/react-theme-provider@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@callstack/react-theme-provider/-/react-theme-provider-3.0.9.tgz#01035fa1231f1fffc1a806be1b55eb82716e80c1"
+  integrity sha512-tTQ0uDSCL0ypeMa8T/E9wAZRGKWj8kXP7+6RYgPTfOPs9N07C9xM8P02GJ3feETap4Ux5S69D9nteq9mEj86NA==
+  dependencies:
+    deepmerge "^3.2.0"
+    hoist-non-react-statics "^3.3.0"
+
 "@commitlint/cli@^19.4.0":
   version "19.7.1"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-19.7.1.tgz#aca351ae6200af58b49de58181319015e7429601"
@@ -3204,7 +3212,7 @@ collect-v8-coverage@^1.0.0:
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz#c0b29bcd33bcd0779a1344c2136051e6afd3d9e9"
   integrity sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -3228,13 +3236,21 @@ color-name@^1.0.0, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^1.9.0:
+color-string@^1.6.0, color-string@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
   integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
+
+color@^3.1.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 color@^4.2.3:
   version "4.2.3"
@@ -3522,6 +3538,11 @@ deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
+deepmerge@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.3.0.tgz#d3c47fd6f3a93d517b14426b0628a17b0125f5f7"
+  integrity sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==
 
 deepmerge@^4.2.2, deepmerge@^4.3.0:
   version "4.3.1"
@@ -6973,6 +6994,15 @@ react-native-motion-tabs@^1.0.6:
   resolved "https://registry.yarnpkg.com/react-native-motion-tabs/-/react-native-motion-tabs-1.0.12.tgz#360accf4da10fce006fc4459cf694a21d9ec693f"
   integrity sha512-oToh+7w7wcuSHG0aZjJXoPkoFWN3Dt9n5cJXNZQvAXnSMLCRiy6i4HLbUd5TEHGJeGzXgSF7bC1GuDCQqT4ukw==
 
+react-native-paper@^5.13.1:
+  version "5.13.1"
+  resolved "https://registry.yarnpkg.com/react-native-paper/-/react-native-paper-5.13.1.tgz#50217012b2d008397296c9bfb755d603a373f48b"
+  integrity sha512-8frKVKJ5JBd8WL1G3tpcYzOgK40kxkD/U+yLHGKNeLnD6v1Qc9W6DxWTHWN7lsX/DPYnhgvw1aKkYaPTmDj5pg==
+  dependencies:
+    "@callstack/react-theme-provider" "^3.0.9"
+    color "^3.1.2"
+    use-latest-callback "^0.1.5"
+
 react-native-purchases@^8.5.0:
   version "8.5.2"
   resolved "https://registry.yarnpkg.com/react-native-purchases/-/react-native-purchases-8.5.2.tgz#ef7d75019acafca24bde93d9f669671b14f98ae4"
@@ -8253,6 +8283,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-latest-callback@^0.1.5:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/use-latest-callback/-/use-latest-callback-0.1.11.tgz#e073fcbba792cc95ac661d96bc13b6041956cfe1"
+  integrity sha512-8nhb73STSD/z3GTHklvNjL8F9wMOo0bj0AFnulpIYuFTm6aQlT3ZcNbXF2YurKImIY8+kpSFSDHZZyQmurGrhw==
 
 use-latest-callback@^0.2.1:
   version "0.2.3"


### PR DESCRIPTION
### ✨ Description:
Temporarily replaced the deprecated (from 0.75.0) UIManagerModule.showPopupMenu() from Android with the react-native-paper menu component, until the React Native team fixes the issue described in [this issue](https://github.com/facebook/react-native/issues/49112).

🛠 Changes:
- [X] : Replaced showPopupMenu with react-native-paper component.
- [X] : Install react-native-paper
- [X] : Implemented FavoritesOptionsMenu component to use on Android.

### 🧪 How Has This Been Tested?

- [x] Tested on iOS
- [x] Tested on Android